### PR TITLE
fix broken start/stop scanning calls and sample

### DIFF
--- a/ios-beacon-tools/RNLBeaconScanner.h
+++ b/ios-beacon-tools/RNLBeaconScanner.h
@@ -31,8 +31,8 @@
 
 + (instancetype) sharedBeaconScanner;
 
-- (void) startScanning;
-- (void) stopScanning;
+- (void) startScanningAltbeacons;
+- (void) stopScanningAltbeacons;
 - (NSNumber *) calibratedRSSIFor: (RNLBeacon *)beacon;
 - (NSArray *) trackedBeacons;
 

--- a/ios-beacon-tools/RNLBeaconScanner.m
+++ b/ios-beacon-tools/RNLBeaconScanner.m
@@ -67,11 +67,11 @@
     
     self.beaconTracker = [[RNLBeaconTracker alloc] init];
     
-    [self startScanning];
+    [self startScanningAltbeacons];
     return self;
 }
 - (void) dealloc {
-    [self stopScanning];
+    [self stopScanningAltbeacons];
 }
 
 - (void)startScanningAltbeacons {

--- a/sample.swift
+++ b/sample.swift
@@ -12,7 +12,7 @@ class Sample {
     var scanner: RNLBeaconScanner?
     func sample() {
         scanner = RNLBeaconScanner.shared()
-        scanner?.startScanning()
+        scanner?.startScanningAltbeacons()
         
         // Execute this code periodically (every second or so) to view the beacons detected
         if let detectedBeacons = scanner?.trackedBeacons() as? [RNLBeacon] {


### PR DESCRIPTION
Method signatures are different in the header from the actual method. Corrected that and updated the sample.